### PR TITLE
Fix redeemer lookup by preserving input order

### DIFF
--- a/aiken/crates/uplc/src/tx/script_context.rs
+++ b/aiken/crates/uplc/src/tx/script_context.rs
@@ -518,7 +518,6 @@ pub fn get_tx_in_info_v1(
 ) -> Result<Vec<TxInInfo>, Error> {
     inputs
         .iter()
-        .sorted()
         .map(|input| {
             let utxo = match utxos.iter().find(|utxo| utxo.input == *input) {
                 Some(resolved) => resolved,
@@ -567,7 +566,6 @@ pub fn get_tx_in_info_v2(
 ) -> Result<Vec<TxInInfo>, Error> {
     inputs
         .iter()
-        .sorted()
         .map(|input| {
             let utxo = match utxos.iter().find(|utxo| utxo.input == *input) {
                 Some(resolved) => resolved,


### PR DESCRIPTION
## Summary
- stop sorting transaction inputs when building lookup tables so the indexes match the original order
- ensure redeemer lookups receive the correct spending input instead of the wallet key hash

## Testing
- cargo run

------
https://chatgpt.com/codex/tasks/task_e_68e458d3be5c832db3bf3442b8bd479c